### PR TITLE
Score miners based on the accuracy and response time

### DIFF
--- a/src/subnet/validator/validator.py
+++ b/src/subnet/validator/validator.py
@@ -424,7 +424,8 @@ class TextValidator(Module):
         
         process_time_score = {uid: miner_answer["process_time"].total_seconds() for uid, miner_answer in miner_results}
         max_time = max(process_time_score.values())
-        process_time_score = {uid: 1 - max_time / process_time for uid, process_time in process_time_score.items()}
+        min_time = min(process_time_score.values())
+        process_time_score = {uid: 1 - 0.5 * (process_time - min_time) / (max_time - min_time) for uid, process_time in process_time_score.items()}
         
         overall_score = {uid: (accuracy_score[uid] + process_time_score[uid]) / 2 for uid in accuracy_score.keys()}
         return overall_score


### PR DESCRIPTION
Score miners based on the accuracy of result and response time

- accuracy
  - give 1 to trust miner
  - penalty miners based on the number of wrong blocks
  - if rate of correct block is lower than 75%, give 0 to miner
- response time
  - give fastest miner to 1
  - give 0.5 to lowest miner
